### PR TITLE
[FEAT] 네일 업로드 시 마스크 적용 기능 추가

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      sharp:
+        specifier: ^0.33.5
+        version: 0.33.5
       sonner:
         specifier: ^2.0.1
         version: 2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -6622,13 +6625,11 @@ snapshots:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
-    optional: true
 
   color@4.2.3:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
-    optional: true
 
   combined-stream@1.0.8:
     dependencies:
@@ -6739,8 +6740,7 @@ snapshots:
 
   denque@2.1.0: {}
 
-  detect-libc@2.0.3:
-    optional: true
+  detect-libc@2.0.3: {}
 
   detect-node-es@1.1.0: {}
 
@@ -7360,8 +7360,7 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-arrayish@0.3.2:
-    optional: true
+  is-arrayish@0.3.2: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -8129,7 +8128,6 @@ snapshots:
       '@img/sharp-wasm32': 0.33.5
       '@img/sharp-win32-ia32': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -8170,7 +8168,6 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
-    optional: true
 
   snake-case@3.0.4:
     dependencies:

--- a/src/server/lib/s3.ts
+++ b/src/server/lib/s3.ts
@@ -1,5 +1,5 @@
 import 'server-only'
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3'
 import crypto from 'crypto'
 
 const s3Client = new S3Client({
@@ -34,5 +34,27 @@ export async function uploadToS3(file: File): Promise<string> {
   } catch (error) {
     console.error('S3 Upload Error:', error)
     throw new Error('파일 업로드 중 오류가 발생했습니다.')
+  }
+}
+
+export async function getImageFromS3(bucket: string, key: string): Promise<Buffer> {
+  try {
+    const command = new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+    });
+    
+    const response = await s3Client.send(command);
+    
+    // 응답 본문을 버퍼로 변환
+    const chunks: Buffer[] = [];
+    for await (const chunk of response.Body as any) {
+      chunks.push(Buffer.from(chunk));
+    }
+    
+    return Buffer.concat(chunks);
+  } catch (error) {
+    console.error('S3에서 이미지 가져오기 실패:', error);
+    throw new Error(`S3에서 이미지를 가져올 수 없습니다: ${bucket}/${key}`);
   }
 }

--- a/src/server/repositories/aiResultRepository.ts
+++ b/src/server/repositories/aiResultRepository.ts
@@ -94,6 +94,62 @@ export class AiResultRepository {
   async transaction<T>(callback: (tx: Prisma.TransactionClient) => Promise<T>): Promise<T> {
     return prisma.$transaction(callback)
   }
+
+  // ── 트랜잭션 전용 메서드 ──
+
+  // 트랜잭션 내에서 삭제 처리 
+  async deleteAiAssetInTx(tx: Prisma.TransactionClient, id: number, deletedBy: number) {
+    return tx.nail_assets.update({
+      where: {
+        id,
+        asset_type: 'ai_generated'
+      },
+      data: {
+        deleted_at: new Date(),
+        deleted_by: deletedBy
+      }
+    })
+  }
+
+  // 트랜잭션 내에서 자산 조회
+  async findByIdInTx(tx: Prisma.TransactionClient, id: number) {
+    return tx.nail_assets.findUnique({
+      where: {
+        id,
+        asset_type: 'ai_generated'
+      }
+    })
+  }
+
+  // 트랜잭션 내에서 nail_tip 생성
+  async createNailTipInTx(
+    tx: Prisma.TransactionClient,
+    data: { imageUrl: string; shape: Shape; category: Category; color: Color; checkedBy: number }
+  ) {
+    return tx.nail_tip.create({
+      data: {
+        image_url: data.imageUrl,
+        shape: data.shape,
+        category: data.category,
+        color: data.color,
+        checked_by: data.checkedBy
+      }
+    })
+  }
+
+  // 트랜잭션 내에서 삭제 처리 (승인 후 삭제, deleted_by에 null)
+  async markAssetAsDeletedInTx(tx: Prisma.TransactionClient, id: number, deletedBy: number | null) {
+    return tx.nail_assets.update({
+      where: {
+        id,
+        asset_type: 'ai_generated'
+      },
+      data: {
+        deleted_at: new Date(),
+        deleted_by: deletedBy
+      }
+    })
+  }
 }
 
 // 싱글톤 인스턴스 생성

--- a/src/server/utils/image.ts
+++ b/src/server/utils/image.ts
@@ -1,0 +1,100 @@
+import { Shape } from "@/types/nail";
+import sharp from "sharp";
+import { getImageFromS3 } from "../lib/s3";
+
+export function chooseMaskPathBasedOnShape(shape: Shape): { bucket: string, key: string } {
+  // S3 경로 형식으로 변경 (버킷/키 형식)
+  const maskMapping: Record<Shape, { bucket: string, key: string }> = {
+    ROUND: { 
+      bucket: process.env.AWS_BUCKET_NAME || 'nailian-assets', 
+      key: 'base/round.png' 
+    },
+    SQUARE: { 
+      bucket: process.env.AWS_BUCKET_NAME || 'nailian-assets', 
+      key: 'base/square.png' 
+    },
+    STILETTO: { 
+      bucket: process.env.AWS_BUCKET_NAME || 'nailian-assets', 
+      key: 'base/stiletto.png' 
+    },
+    BALLERINA: { 
+      bucket: process.env.AWS_BUCKET_NAME || 'nailian-assets', 
+      key: 'base/ballerina.png' 
+    },
+    ALMOND: { 
+      bucket: process.env.AWS_BUCKET_NAME || 'nailian-assets', 
+      key: 'base/almond.png' 
+    },
+  };
+  
+  // 객체 직접 반환
+  return maskMapping[shape];
+}
+
+  
+export async function processImageWithMask(maskInfo: { bucket: string, key: string }, imageBuffer: Buffer): Promise<Buffer> {
+  try {
+    // 마스크 이미지 가져오기
+    const maskBuffer = await getImageFromS3(maskInfo.bucket, maskInfo.key);
+
+    // 베이스 이미지(마스크) 정보 가져오기
+    const baseImageInfo = await sharp(maskBuffer).metadata();
+
+    // 컬러 네일 이미지 리사이징 (Nearest Neighbor 방식)
+    const resizedColorNail = await sharp(imageBuffer)
+      .resize({
+        width: baseImageInfo.width,
+        height: baseImageInfo.height,
+        kernel: sharp.kernel.nearest,
+        fit: 'fill'
+      })
+      .toBuffer();
+
+    // 베이스 이미지에서 투명한 부분 마스크 추출
+    const { data: baseData, info: baseInfo } = await sharp(maskBuffer)
+      .ensureAlpha()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+
+    // 리사이징된 컬러 네일 이미지 로드
+    const { data: colorData, info: colorInfo } = await sharp(resizedColorNail)
+      .ensureAlpha()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+
+    // 새 이미지 데이터 생성
+    const pixelCount = baseInfo.width * baseInfo.height;
+    const newData = Buffer.alloc(pixelCount * 4);
+
+    // 픽셀 단위로 처리 (베이스 이미지의 투명한 부분에만 tip 이미지 픽셀 적용)
+    for (let i = 0; i < pixelCount; i++) {
+      const baseAlpha = baseData[i * 4 + 3];
+      
+      // 베이스 이미지가 투명한 부분 (알파값 1 미만)인 경우 tip 이미지 픽셀 사용
+      if (baseAlpha < 1) {
+        newData[i * 4] = colorData[i * 4];       // R
+        newData[i * 4 + 1] = colorData[i * 4 + 1]; // G
+        newData[i * 4 + 2] = colorData[i * 4 + 2]; // B
+        newData[i * 4 + 3] = colorData[i * 4 + 3]; // A
+      } else {
+        // 나머지는 완전 투명 처리
+        newData[i * 4] = 0;
+        newData[i * 4 + 1] = 0;
+        newData[i * 4 + 2] = 0;
+        newData[i * 4 + 3] = 0;
+      }
+    }
+
+    // 새 이미지 생성 및 버퍼로 반환
+    return await sharp(newData, {
+      raw: {
+        width: baseInfo.width,
+        height: baseInfo.height,
+        channels: 4
+      }
+    }).png().toBuffer();
+  } catch (error: any) {
+    console.error('이미지 처리 중 오류 발생:', error);
+    throw new Error(`이미지 처리 중 오류: ${error.message}`);
+  }
+}


### PR DESCRIPTION
### 📌 작업 개요 

네일 팁의 크기, 즉 픽셀 개수를 일정하게 유지하기 위하여 베이스 이미지를 통한 마스크 적용 기능 추가

### ✅ 작업 항목 

- 일부 트랜젝션 관련 로직 레포지토리로 이동
- getImageFromS3 추가
- 마스크 정보를 활용하여 네일 이미지 리사이징
