### PR TITLE
[FEAT] 인터셉터 토큰 재발급 로직 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default async function RootLayout({
 }) {
   // 서버에서 인증 상태 확인
   const cookieStore = await cookies()
-  const isAuthenticated = !!cookieStore.get('accessToken')
+  const isAuthenticated = !!cookieStore.get('accessToken') || !!cookieStore.get('refreshToken')
 
   return (
     <html lang="ko">

--- a/src/lib/api/instance.ts
+++ b/src/lib/api/instance.ts
@@ -1,6 +1,11 @@
-import axios, { AxiosError, AxiosResponse } from 'axios'
+import axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { ApiSuccessResponse, ApiResponseCode, ApiErrorResponse } from '@/types/api/response'
 import { redirect } from 'next/navigation'
+
+// Axios 설정 타입 확장
+interface ExtendedAxiosRequestConfig extends InternalAxiosRequestConfig {
+    _retry?: boolean;
+}
 
 // 응답 타입
 export interface ApiResponse<T> {
@@ -30,30 +35,86 @@ export const api = axios.create({
     headers: {
         'Content-Type': 'application/json',
     },
+    // 쿠키를 요청에 포함하도록 설정
+    withCredentials: true
 })
+
+// 토큰 재발급 요청 중인지 확인하는 플래그
+let isRefreshing = false
+// 토큰 재발급 대기 중인 요청들을 저장하는 배열
+let refreshSubscribers: ((token: string) => void)[] = []
+
+// 토큰 재발급 후 대기 중인 요청들을 처리하는 함수
+const onRefreshed = (token: string) => {
+    refreshSubscribers.forEach(callback => callback(token))
+    refreshSubscribers = []
+}
+
+// 토큰 재발급을 기다리는 함수
+const addRefreshSubscriber = (callback: (token: string) => void) => {
+    refreshSubscribers.push(callback)
+}
 
 // 응답 인터셉터
 api.interceptors.response.use(
     (response: AxiosResponse<ApiSuccessResponse<unknown>>) => {
         const { data } = response
+        
+        // SUCCESS나 CREATED가 아닌 다른 에러 코드 처리
         if (data.code !== ApiResponseCode.SUCCESS && data.code !== ApiResponseCode.CREATED) {
             throw new ApiError(
-                ApiResponseCode.INTERNAL_ERROR,
-                'Invalid response code'
+                data.code,
+                data.message || 'Invalid response code'
             )
         }
+
         return {
             ...response,
             data: data.data
         }
     },
-    (error: AxiosError<ApiErrorResponse>) => {
+    async (error: AxiosError<ApiErrorResponse>) => {
         if (error.response) {
+            const { status } = error.response
             const { code, message, error: responseError } = error.response.data
+            const originalRequest = error.config as ExtendedAxiosRequestConfig
 
             // 401 Unauthorized 처리
-            if (code === ApiResponseCode.UNAUTHORIZED) {
-                redirect('/login')
+            if (status === 401 && originalRequest && !originalRequest._retry) {
+                if (!isRefreshing) {
+                    isRefreshing = true
+                    originalRequest._retry = true
+
+                    console.log('토큰 재발급 시작')
+                    try {
+                        // 토큰 재발급 요청 (withCredentials 명시적 설정)
+                        await api.post('/auth/refresh', {}, { 
+                            withCredentials: true 
+                        })
+
+                        // 대기 중인 요청들 처리
+                        onRefreshed('') // 토큰 값은 쿠키에 있으므로 빈 문자열 전달
+                        isRefreshing = false
+
+                        // 모든 후속 요청에도 withCredentials 설정
+                        originalRequest.withCredentials = true;
+                        
+                        // 실패했던 요청 재시도
+                        return api(originalRequest)
+                    } catch {
+                        isRefreshing = false
+                        refreshSubscribers = []
+                        // 리프레시 토큰도 만료된 경우 로그인 페이지로 리다이렉트
+                        redirect('/login')
+                    }
+                }
+
+                // 토큰 재발급 중인 경우, 새로운 Promise 반환
+                return new Promise(resolve => {
+                    addRefreshSubscriber(() => {
+                        resolve(api(originalRequest))
+                    })
+                })
             }
 
             throw new ApiError(code, message, responseError?.details)

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
     const { pathname } = request.nextUrl
-    const isAuthenticated = request.cookies.has('accessToken')  // 쿠키에서 토큰 확인
+    const isAuthenticated = request.cookies.has('accessToken') || request.cookies.has('refreshToken')
 
     // 공개 경로 목록 (로그인하지 않아도 접근 가능한 경로)
     const publicPaths = ['/login', '/api/auth/login', '/api/auth/signup', '/images']


### PR DESCRIPTION
### 📌 작업 개요 
응답 인터셉터에서  토큰 재발급 로직 추가
### ✅ 작업 항목 

- 리프레쉬 토큰이 있는 경우에도 헤더 메뉴 표시
- 401 응답 발생 시 인터셉터 내 리이슈 로직 추가