### PR TITLE
[DRAFT] [CI/CD] arm 빌드 최적화

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -6,19 +6,11 @@ on:
       - main
 
 jobs:
-  build-docker:
-    runs-on: ${{ matrix.os }}
+  args:
+    runs-on: ubuntu-24.04
     outputs:
-      docker_image_name: ${{ steps.repo_name.outputs.lowercase }}
+      encrypted_docker_image_name: ${{ steps.encrypted.outputs.encrypted_docker_image_name }}
       commit_short_sha: ${{ steps.sha.outputs.SHORT_SHA }}
-
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-24.04
-            arch: amd64
-          - os: ubuntu-24.04-arm
-            arch: arm64
 
     steps:
       - name: Check out the repository
@@ -35,7 +27,41 @@ jobs:
           string: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
 
-      - run: echo "BUILDX_CACHE_PATH=/tmp/buildx-cache" >> $GITHUB_ENV
+      - name: Encrypt repo name
+        id: encrypted
+        run: |
+          PLAIN_TEXT=${{ steps.repo_name.outputs.lowercase }}
+          BINARY_ENCRYPTED=$(echo -n "$PLAIN_TEXT" | openssl enc -aes-256-cbc -pbkdf2 -salt -k "${{ secrets.ENCRYPTION_PASSWORD }}")
+          ENCRYPTED=$(echo -n "$BINARY_ENCRYPTED" | base64)
+          echo "encrypted_docker_image_name=$ENCRYPTED" >> $GITHUB_OUTPUT
+
+  build-docker:
+    runs-on: ${{ matrix.os }}
+    needs:
+      - args
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+
+    env:
+      BUILDX_CACHE_PATH: /tmp/buildx-cache
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Load arguments
+        id: args
+        run: |
+          ENCRYPTED=${{ needs.args.outputs.encrypted_docker_image_name }}
+          BINARY_ENCRYPTED=$(echo -n "$ENCRYPTED" | base64 --decode)
+          DECRYPTED=$(echo -n "$BINARY_ENCRYPTED" | openssl enc -aes-256-cbc -pbkdf2 -d -salt -k "${{ secrets.ENCRYPTION_PASSWORD }}")
+          echo "COMMIT_SHORT_SHA=${{ needs.args.outputs.commit_short_sha }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_NAME=$DECRYPTED" >> $GITHUB_ENV
 
       - name: Load cache if available
         uses: actions/cache/restore@v4
@@ -61,7 +87,7 @@ jobs:
           cache-to: type=local,dest=${{ env.BUILDX_CACHE_PATH }},mode=max,compression=zstd
           platforms: linux/${{ matrix.arch }}
           tags: |
-            ${{ steps.repo_name.outputs.lowercase }}:${{ steps.sha.outputs.SHORT_SHA }}-${{ matrix.arch }}
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ env.COMMIT_SHORT_SHA }}-${{ matrix.arch }}
 
       - name: Save cache
         uses: actions/cache/save@v4
@@ -73,21 +99,20 @@ jobs:
   merge-image-manifest:
     runs-on: ubuntu-latest
     needs:
+      - args
       - build-docker
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Get short SHA
-        id: sha
-        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Get lowercase repo name
-        id: repo_name
-        uses: ASzc/change-string-case-action@v6
-        with:
-          string: |
-            ${{ needs.build-docker.outputs.docker_image_name }}
+      - name: Load arguments
+        id: args
+        run: |
+          ENCRYPTED=${{ needs.args.outputs.encrypted_docker_image_name }}
+          BINARY_ENCRYPTED=$(echo -n "$ENCRYPTED" | base64 --decode)
+          DECRYPTED=$(echo -n "$BINARY_ENCRYPTED" | openssl enc -aes-256-cbc -pbkdf2 -d -salt -k "${{ secrets.ENCRYPTION_PASSWORD }}")
+          echo "COMMIT_SHORT_SHA=${{ needs.args.outputs.commit_short_sha }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_NAME=$DECRYPTED" >> $GITHUB_ENV
 
       - uses: docker/login-action@v3
         with:
@@ -97,10 +122,10 @@ jobs:
       - name: Create and Push manifest list
         run: |
           docker buildx imagetools create \
-            -t ${{ needs.build-docker.outputs.docker_image_name }}:${{ needs.build-docker.outputs.commit_short_sha }} \
-            -t ${{ needs.build-docker.outputs.docker_image_name }}:dev \
-            ${{ needs.build-docker.outputs.docker_image_name }}:${{ needs.build-docker.outputs.commit_short_sha }}-amd64 \
-            ${{ needs.build-docker.outputs.docker_image_name }}:${{ needs.build-docker.outputs.commit_short_sha }}-arm64
+            -t ${{ env.DOCKER_IMAGE_NAME }}:${{ env.COMMIT_SHORT_SHA }} \
+            -t ${{ env.DOCKER_IMAGE_NAME }}:dev \
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ env.COMMIT_SHORT_SHA }}-amd64 \
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ env.COMMIT_SHORT_SHA }}-arm64
 
   trigger-deploy-infra:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -60,7 +60,7 @@ jobs:
           tags: |
             ${{ steps.repo_name.outputs.lowercase }}:${{ steps.sha.outputs.SHORT_SHA }}-${{ matrix.arch }}
 
-      - name: Load cache if available
+      - name: Save cache
         uses: actions/cache/save@v4
         id: save_cache
         with:

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -79,6 +79,9 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
+      - run: |
+          ls -alh
+
       - name: Build Image (per architecture)
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -29,9 +29,8 @@ jobs:
         id: repo_name
         uses: ASzc/change-string-case-action@v6
         with:
-          # 테스트 중이므로 Docker Hub의 저장소 이름을 'test'로 사용
           string: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/test
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
 
       - run: echo "BUILDX_CACHE_PATH=/tmp/buildx-cache" >> $GITHUB_ENV
 

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -46,8 +46,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.os }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.os }}-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
           tags: |
             ${{ steps.repo_name.outputs.lowercase }}:${{ steps.sha.outputs.SHORT_SHA }}-${{ matrix.arch }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -64,17 +64,6 @@ jobs:
           echo "COMMIT_SHORT_SHA=${{ needs.args.outputs.commit_short_sha }}" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_NAME=$DECRYPTED" >> $GITHUB_ENV
 
-      - name: Load cache if available
-        uses: actions/cache@v4
-        id: load_cache
-        with:
-          path: ${{ env.BUILDX_CACHE_PATH }}
-          key: ${{ env.BUILDX_CACHE_NAME }}-${{ matrix.os }}-${{ matrix.arch }}-${{ env.COMMIT_SHORT_SHA }}
-          restore-keys: |
-            ${{ env.BUILDX_CACHE_NAME }}-${{ matrix.os }}-${{ matrix.arch }}-
-            ${{ env.BUILDX_CACHE_NAME }}-${{ matrix.os }}-
-            ${{ env.BUILDX_CACHE_NAME }}-
-
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -94,8 +83,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          cache-from: type=local,src=${{ env.BUILDX_CACHE_PATH }}
-          cache-to: type=local,dest=${{ env.BUILDX_CACHE_PATH }},mode=max,compression=zstd
+          cache-from: type=gha,scope=${{ matrix.os }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.os }}-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
           tags: |
             ${{ env.DOCKER_IMAGE_NAME }}:${{ env.COMMIT_SHORT_SHA }}-${{ matrix.arch }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           push: true
           cache-from: type=gha,scope=${{ matrix.os }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.os }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=min,compression=zstd,scope=${{ matrix.os }}-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
           tags: |
             ${{ steps.repo_name.outputs.lowercase }}:${{ steps.sha.outputs.SHORT_SHA }}-${{ matrix.arch }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           push: true
           cache-from: type=gha,scope=${{ matrix.os }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=min,compression=zstd,scope=${{ matrix.os }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,compression=zstd,scope=${{ matrix.os }}-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
           tags: |
             ${{ steps.repo_name.outputs.lowercase }}:${{ steps.sha.outputs.SHORT_SHA }}-${{ matrix.arch }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -49,6 +49,7 @@ jobs:
 
     env:
       BUILDX_CACHE_PATH: /tmp/buildx-cache
+      BUILDX_CACHE_NAME: buildx-cache
 
     steps:
       - name: Check out the repository
@@ -64,11 +65,15 @@ jobs:
           echo "DOCKER_IMAGE_NAME=$DECRYPTED" >> $GITHUB_ENV
 
       - name: Load cache if available
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v4
         id: load_cache
         with:
           path: ${{ env.BUILDX_CACHE_PATH }}
-          key: buildx-cache-${{ matrix.os }}-${{ matrix.arch }}
+          key: ${{ env.BUILDX_CACHE_NAME }}-${{ matrix.os }}-${{ matrix.arch }}-${{ env.COMMIT_SHORT_SHA }}
+          restore-keys: |
+            ${{ env.BUILDX_CACHE_NAME }}-${{ matrix.os }}-${{ matrix.arch }}-
+            ${{ env.BUILDX_CACHE_NAME }}-${{ matrix.os }}-
+            ${{ env.BUILDX_CACHE_NAME }}-
 
       - uses: docker/login-action@v3
         with:
@@ -91,13 +96,6 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           tags: |
             ${{ env.DOCKER_IMAGE_NAME }}:${{ env.COMMIT_SHORT_SHA }}-${{ matrix.arch }}
-
-      - name: Save cache
-        uses: actions/cache/save@v4
-        id: save_cache
-        with:
-          path: ${{ env.BUILDX_CACHE_PATH }}
-          key: ${{ steps.load_cache.outputs.cache-primary-key }}
 
   merge-image-manifest:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -6,8 +6,11 @@ on:
       - main
 
 jobs:
-  build-and-push-docker:
+  build-docker:
     runs-on: ${{ matrix.os }}
+    outputs:
+      docker_image_name: ${{ steps.repo_name.outputs.lowercase }}
+      commit_short_sha: ${{ steps.sha.outputs.SHORT_SHA }}
 
     strategy:
       matrix:
@@ -70,7 +73,7 @@ jobs:
   merge-image-manifest:
     runs-on: ubuntu-latest
     needs:
-      - build-and-push-docker
+      - build-docker
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
@@ -84,7 +87,7 @@ jobs:
         uses: ASzc/change-string-case-action@v6
         with:
           string: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/test
+            ${{ needs.build-docker.outputs.docker_image_name }}
 
       - uses: docker/login-action@v3
         with:
@@ -94,10 +97,10 @@ jobs:
       - name: Create and Push manifest list
         run: |
           docker buildx imagetools create \
-            -t ${{ steps.repo_name.outputs.lowercase }}:${{ steps.sha.outputs.SHORT_SHA }} \
-            -t ${{ steps.repo_name.outputs.lowercase }}:dev \
-            ${{ steps.repo_name.outputs.lowercase }}:${{ steps.sha.outputs.SHORT_SHA }}-amd64 \
-            ${{ steps.repo_name.outputs.lowercase }}:${{ steps.sha.outputs.SHORT_SHA }}-arm64
+            -t ${{ needs.build-docker.outputs.docker_image_name }}:${{ needs.build-docker.outputs.commit_short_sha }} \
+            -t ${{ needs.build-docker.outputs.docker_image_name }}:dev \
+            ${{ needs.build-docker.outputs.docker_image_name }}:${{ needs.build-docker.outputs.commit_short_sha }}-amd64 \
+            ${{ needs.build-docker.outputs.docker_image_name }}:${{ needs.build-docker.outputs.commit_short_sha }}-arm64
 
   trigger-deploy-infra:
     runs-on: ubuntu-latest
@@ -105,6 +108,7 @@ jobs:
       - merge-image-manifest
     steps:
       - name: Dispatch event for Admin Deployment
+        if: ${{ github.repository_owner == 'Snail-Official' }}
         run: gh api /repos/snail-official/nailian-iac/dispatches -f event_type='restart-admin-dev'
         env:
           GH_TOKEN: ${{ secrets.GH_TRIGGER_TOKEN }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -33,6 +33,15 @@ jobs:
           string: |
             ${{ secrets.DOCKERHUB_USERNAME }}/test
 
+      - run: echo "BUILDX_CACHE_PATH=/tmp/buildx-cache" >> $GITHUB_ENV
+
+      - name: Load cache if available
+        uses: actions/cache/restore@v4
+        id: load_cache
+        with:
+          path: ${{ env.BUILDX_CACHE_PATH }}
+          key: buildx-cache-${{ matrix.os }}-${{ matrix.arch }}
+
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -46,11 +55,18 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          cache-from: type=gha,scope=${{ matrix.os }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,compression=zstd,scope=${{ matrix.os }}-${{ matrix.arch }}
+          cache-from: type=local,src=${{ env.BUILDX_CACHE_PATH }}
+          cache-to: type=local,dest=${{ env.BUILDX_CACHE_PATH }},mode=max,compression=zstd
           platforms: linux/${{ matrix.arch }}
           tags: |
             ${{ steps.repo_name.outputs.lowercase }}:${{ steps.sha.outputs.SHORT_SHA }}-${{ matrix.arch }}
+
+      - name: Load cache if available
+        uses: actions/cache/save@v4
+        id: save_cache
+        with:
+          path: ${{ env.BUILDX_CACHE_PATH }}
+          key: ${{ steps.load_cache.outputs.cache-primary-key }}
 
   merge-image-manifest:
     runs-on: ubuntu-latest

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
+
 export function middleware(request: NextRequest) {
     const { pathname } = request.nextUrl
     const isAuthenticated = request.cookies.has('accessToken') || request.cookies.has('refreshToken')


### PR DESCRIPTION
## 요약
`arm64` 아키텍처 빌드 시 캐시가 제대로 적용되지 않아 생기는 문제를 해결함

<br/>

## 설명
우리 프로젝트의 전체 파이프라인에서 공통적으로 `arm64` 빌드가 오래 걸리는 현상이 있습니다. 

cross-platform build 에서 `amd64` 의 빌드가 비교적 빨리 끝나서 Github Actions 에 캐시를 저장했는데요, `arm64` 가 뒤늦게 빌드를 끝내고 캐시르 저장할 때 `amd64` 에서 사용한 캐시 키와 같은 키로 저장을 시도했기 때문에 저장이 제대로 되지 않았던 것을 원인으로 파악했습니다. 

> arm64 빌드에서 캐시가 제대로 작동하지 않아 node_modules 를 다시 받아오는 모습
> ![image](https://github.com/user-attachments/assets/59533e57-f557-42ca-a1b1-8942a2eba2b6)

<br/>

또한 Github Actions Cache 에 캐시를 내보내기 위해 준비하는 시간이 현저히 느린 것을 확인했습니다. 

> arm64 기준 70s 소요
> ![image](https://github.com/user-attachments/assets/87ea774d-268e-4ab8-9ff9-b135d693d28f)

<br />

이에 다음의 변경을 적용했습니다.
1. 캐시 방식 변경
    - Github Actions Cache 수동 업/다운로드
    - `docker/build-push-action@v6` 에서 자동으로 관리해주는 방식이 모종의 이유로 매우 느림 (~70s)
    - `local` 방식으로 로컬 파일시스템에 캐시를 내보낸 후 `actions/cache@v4` 로 관리
        - Cache 를 불러올 때 Cache Key 를 여러 가지의 candidate 로 관리할 수 있어서 캐시 중복 문제가 생기지 않음
        - 필요 시 docker buildx 내부에서 발생한 내용도 캐싱 가능 (유연한 캐싱 가능)
2. 기타 개선사항
    - 하드코딩된 도커 이미지 이름을 Secrets 로 처리
    - job 간의 각종 인자 공유 처리

<br/>

## 결과
<table>
    <tr>
        <th rowspan="2">캐시 유/무</th>
        <th rowspan="2">측정 항목</th>
        <th colspan="3">AMD64</th>
        <th colspan="3">ARM64</th>
    </tr>
    <tr>
        <th>개선 전</th>
        <th>개선 후</th>
        <th>비율</th>
        <th>개선 전</th>
        <th>개선 후</th>
        <th>비율</th>
    </tr>
    <tr>
        <td rowspan="5">캐시 O</td>
        <td>전체 실행시간</td>
        <td>1m 43.0s</td>
        <td>1m 46.0s</td>
        <td>+2.91%</td>
        <td>2m 38.0s</td>
        <td>2m 12.0s</td>
        <td>-16.46%</td>
    </tr>
    <tr>
        <td>빌드</td>
        <td>1m 23.0s</td>
        <td>1m 25.0s</td>
        <td>+2.41%</td>
        <td>1m 56.0s</td>
        <td>1m 31.0s</td>
        <td>-22.55%</td>
    </tr>
    <tr>
        <td>next build</td>
        <td>0m 32.7s</td>
        <td>0m 33.8s</td>
        <td>+3.36%</td>
        <td>0m 47.7s</td>
        <td>0m 32.5s</td>
        <td>-31.87%</td>
    </tr>
    <tr>
        <td>이미지 내보내기</td>
        <td>0m 05.3s</td><td>0m 05.1s</td><td>-3.77%</td><td>0m 05.9s</td><td>0m 05.4s</td><td>-8.47%</td>
    </tr>
    <tr>
        <td>캐시 내보내기</td>
        <td>0m 09.1s</td><td>0m 08.4s</td><td>-7.69%</td><td>0m 09.1s</td><td>0m 08.7s</td><td>-4.40%</td>
    </tr>
    <tr>
        <td rowspan="5">캐시 X</td>
        <td>전체 실행시간</td>
        <td>3m 49.0s</td><td>3m 42.0s</td><td>-3.06%</td><td>4m 56.0s</td><td>4m 42.0s</td><td>-4.73%</td>
    </tr>
    <tr>
        <td>빌드</td>
        <td>3m 24.0s</td><td>3m 20.0s</td><td>-1.96%</td><td>3m 56.0s</td><td>3m 45.0s</td><td>-4.66%</td>
    </tr>
    <tr>
        <td>next build</td>
        <td>0m 34.8s</td><td>0m 34.1s</td><td>-2.01%</td><td>0m 35.4s</td><td>0m 34.1s</td><td>-3.67%</td>
    </tr>
    <tr>
        <td>이미지 내보내기</td>
        <td>0m 34.0s</td><td>0m 30.9s</td><td>-9.12%</td><td>0m 35.4s</td><td>0m 33.5s</td><td>-5.37%</td>
    </tr>
    <tr>
        <td>캐시 내보내기</td>
        <td>1m 43.7s</td><td>1m 41.3s</td><td>-2.31%</td><td>1m 35.6s</td><td>1m 31.3s</td><td>-4.50%</td>
    </tr>
</table>




